### PR TITLE
Move schedule to dedicated page

### DIFF
--- a/html/line_8.html
+++ b/html/line_8.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="sr">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Brčko Bus - Red vožnje</title>
+
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+
+  <!-- Custom CSS -->
+<link rel="stylesheet" href="../css/style.css" />
+</head>
+
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="../index.html">Brčko Bus</a>
+    </div>
+  </nav>
+  <!-- Page Banner -->
+  <div class="page-banner">
+    <div class="container">
+      <div class="row">
+        <div class="col-12 text-center">
+          <h1 class="mb-0">Red vožnje</h1>
+          <p class="lead mb-0">Javni gradski prevoz Brčko</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Main Content -->
+  <div class="container">
+    <!-- Schedule Card -->
+    <div class="card schedule-card mb-4">
+      <div class="card-header bg-primary text-white">
+        <div class="d-flex justify-content-between align-items-center">
+          <h4 class="mb-0" id="route-title">Maoča - Omerbegovača</h4>
+          <span class="badge bg-light text-dark" id="line-badge">Linija: 8</span>
+        </div>
+      </div>
+
+      <!-- Route Map Visualization - Hidden on smaller screens -->
+      <div class="d-none d-xxl-block">
+        <div class="card-body">
+          <h5 class="mb-3">Ruta linije</h5>
+          <div class="route-map-container" id="route-map">
+            <div class="route-line"></div>
+            <div class="stations" id="route-stations">
+              <!-- Stations will be dynamically populated -->
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-striped table-hover mb-0" id="schedule-table">
+            <thead class="table-light">
+              <tr>
+                <th class="sticky-col">Stanica</th>
+                <th colspan="18">Vrijeme polaska</th>
+              </tr>
+              <tr id="service-header">
+                <th class="sticky-col"></th>
+                <!-- Service numbers will be dynamically populated -->
+              </tr>
+            </thead>
+            <tbody id="schedule-body">
+              <!-- Schedule data will be dynamically populated -->
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="card-footer">
+        <div class="row">
+          <div class="col-md-6">
+            <h5>Objašnjenje</h5>
+            <ul class="list-unstyled">
+              <li>
+                <small><span class="station-r">R</span>
+                  <strong>Raskrsnica</strong> - stanica na raskrsnici</small>
+              </li>
+              <li>
+                <small><span class="legend-dot regular-dot">●</span>
+                  <strong>Plavo</strong> -
+                  <span id="regular-explanation">Polasci saobraćaju svakodnevno</span></small>
+              </li>
+              <li>
+                <small><span class="legend-dot irregular-dot">●</span>
+                  <strong>Crveno</strong> -
+                  <span id="irregular-explanation">Ne saobraćaju vikendom, praznikom i tokom školskog
+                    raspusta</span></small>
+              </li>
+            </ul>
+          </div>
+          <div class="col-md-6">
+            <h5>Napomene</h5>
+            <ul class="list-unstyled">
+              <li><small>Red vožnje važi od 01.09.2024.</small></li>
+              <li>
+                <small>Provjerite aktuelni red vožnje prije putovanja.</small>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Important Notice -->
+    <div class="alert alert-info">
+      <strong>Važno:</strong> Provjerite aktuelni red vožnje prije putovanja,
+      moguće su izmjene rasporeda.
+    </div>
+  </div>
+
+  <footer class="bg-dark text-light text-center py-3 mt-5">
+    <div class="container">
+      <small>&copy; 2025 Brčko Bus</small>
+    </div>
+  </footer>
+
+  <!-- Bootstrap JS -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+  <!-- Page logic -->
+  <script src="../js/index.js"></script>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -1,20 +1,19 @@
 <!doctype html>
 <html lang="sr">
-
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Brčko Bus - Red vožnje</title>
-
-  <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
-
-  <!-- Custom CSS -->
   <link rel="stylesheet" href="css/style.css" />
 </head>
-
 <body>
-  <!-- Page Banner -->
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">Brčko Bus</a>
+    </div>
+  </nav>
+
   <div class="page-banner">
     <div class="container">
       <div class="row">
@@ -26,97 +25,23 @@
     </div>
   </div>
 
-  <!-- Main Content -->
   <div class="container">
-    <!-- Schedule Card -->
-    <div class="card schedule-card mb-4">
-      <div class="card-header bg-primary text-white">
-        <div class="d-flex justify-content-between align-items-center">
-          <h4 class="mb-0" id="route-title">Maoča - Omerbegovača</h4>
-          <span class="badge bg-light text-dark" id="line-badge">Linija: 8</span>
-        </div>
+    <div class="row">
+      <div class="col-12">
+        <h2 class="mb-3">Linije</h2>
+        <ul class="list-group">
+          <li class="list-group-item">
+            <a href="html/line_8.html">Linija 8 - Maoča - Omerbegovača</a>
+          </li>
+        </ul>
       </div>
-
-      <!-- Route Map Visualization - Hidden on smaller screens -->
-      <div class="d-none d-xxl-block">
-        <div class="card-body">
-          <h5 class="mb-3">Ruta linije</h5>
-          <div class="route-map-container" id="route-map">
-            <div class="route-line"></div>
-            <div class="stations" id="route-stations">
-              <!-- Stations will be dynamically populated -->
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card-body p-0">
-        <div class="table-responsive">
-          <table class="table table-striped table-hover mb-0" id="schedule-table">
-            <thead class="table-light">
-              <tr>
-                <th class="sticky-col">Stanica</th>
-                <th colspan="18">Vrijeme polaska</th>
-              </tr>
-              <tr id="service-header">
-                <th class="sticky-col"></th>
-                <!-- Service numbers will be dynamically populated -->
-              </tr>
-            </thead>
-            <tbody id="schedule-body">
-              <!-- Schedule data will be dynamically populated -->
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="card-footer">
-        <div class="row">
-          <div class="col-md-6">
-            <h5>Objašnjenje</h5>
-            <ul class="list-unstyled">
-              <li>
-                <small><span class="station-r">R</span>
-                  <strong>Raskrsnica</strong> - stanica na raskrsnici</small>
-              </li>
-              <li>
-                <small><span class="legend-dot regular-dot">●</span>
-                  <strong>Plavo</strong> -
-                  <span id="regular-explanation">Polasci saobraćaju svakodnevno</span></small>
-              </li>
-              <li>
-                <small><span class="legend-dot irregular-dot">●</span>
-                  <strong>Crveno</strong> -
-                  <span id="irregular-explanation">Ne saobraćaju vikendom, praznikom i tokom školskog
-                    raspusta</span></small>
-              </li>
-            </ul>
-          </div>
-          <div class="col-md-6">
-            <h5>Napomene</h5>
-            <ul class="list-unstyled">
-              <li><small>Red vožnje važi od 01.09.2024.</small></li>
-              <li>
-                <small>Provjerite aktuelni red vožnje prije putovanja.</small>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Important Notice -->
-    <div class="alert alert-info">
-      <strong>Važno:</strong> Provjerite aktuelni red vožnje prije putovanja,
-      moguće su izmjene rasporeda.
     </div>
   </div>
 
-  <!-- Bootstrap JS -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-
-  <!-- Page logic -->
-  <script src="js/index.js"></script>
+  <footer class="bg-dark text-light text-center py-3 mt-5">
+    <div class="container">
+      <small>&copy; 2025 Brčko Bus</small>
+    </div>
+  </footer>
 </body>
-
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -1,7 +1,7 @@
 // Enhanced JavaScript to load and display the schedule
 async function loadScheduleData() {
   try {
-    const response = await fetch("assets/schedules/line_8.json");
+    const response = await fetch("../assets/schedules/line_8.json");
     const data = await response.json();
 
     displayScheduleData(data);


### PR DESCRIPTION
## Summary
- create a landing page with navigation
- move schedule content to `line_8.html`
- add shared navbar and footer
- update relative paths in the schedule page and JS

## Testing
- `tidy -qe index.html`
- `tidy -qe html/line_8.html`

------
https://chatgpt.com/codex/tasks/task_e_6856a3265cc48328918a51b3882e605e