### PR TITLE
Fix alignment of route map icons and labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -630,8 +630,8 @@ th.regular-service {
 .route-line {
   position: absolute;
   top: 110px;
-  left: 2%;
-  width: 95%;
+  left: 0;
+  width: 100%;
   height: 6px;
   background-color: var(--secondary-color);
   border-radius: 3px;
@@ -666,9 +666,9 @@ th.regular-service {
 .station-name {
   position: absolute;
   top: 80px;
-  left: 24px;
-  transform-origin: bottom left;
-  transform: rotate(-60deg);
+  left: 50%;
+  transform-origin: bottom center;
+  transform: translateX(-50%) rotate(-60deg);
   font-size: 0.75rem;
   font-weight: 600;
   color: #000000;


### PR DESCRIPTION
## Summary
- fix the route line to span the full width
- center station labels over their dots for correct alignment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856a8fd49ac8328bd42af61a674c3df