### PR TITLE
Optimize route search

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -415,6 +415,10 @@ body {
   width: 3rem;
   height: 3rem;
 }
+#route-loading .spinner-border {
+  width: 2rem;
+  height: 2rem;
+}
 
 /* Modal Enhancements */
 .modal-content {

--- a/index.html
+++ b/index.html
@@ -75,6 +75,15 @@
           </div>
         </div> -->
       </div>
+      <div class="d-grid mt-3">
+        <button id="route-search-btn" class="btn btn-primary">Pronađi rute</button>
+      </div>
+      <div id="route-loading" class="text-center mt-3" style="display:none;">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">Učitavanje...</span>
+        </div>
+        <p class="text-muted mt-2">Pretraga...</p>
+      </div>
       <div id="route-results" class="mt-3"></div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- use `stationLinesMap` to track which lines pass each stop
- use this map to limit the schedules that must be searched
- add a dedicated route search button
- show a small loading spinner while searching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863f31844488328973521881c886372