### PR TITLE
Add search button with loading

### DIFF
--- a/css/utils.css
+++ b/css/utils.css
@@ -250,6 +250,11 @@
   padding: 0 11rem;
 }
 
+#route-loading {
+  display: none;
+  height: 0.5rem;
+}
+
 .search-area-padding {
   padding-left: 1rem;
   padding-right: 1rem;

--- a/index.html
+++ b/index.html
@@ -68,6 +68,16 @@
             </div>
           </div>
         </div>
+        <div class="row mt-2">
+          <div class="col-12 d-flex gap-2">
+            <button id="route-search-btn" class="btn btn-primary flex-grow-1">Pretraži</button>
+          </div>
+          <div class="col-12">
+            <div id="route-loading" class="progress" style="display:none;">
+              <div class="progress-bar progress-bar-striped progress-bar-animated" style="width:100%"></div>
+            </div>
+          </div>
+        </div>
         <!-- <div class="d-flex justify-content-center">
           <div class="form-check form-switch my-2">
             <input class="form-check-input" type="checkbox" id="multi-transfer-toggle">

--- a/js/path-search.js
+++ b/js/path-search.js
@@ -581,15 +581,39 @@
             }
         }
 
-        startInput.addEventListener('input', update);
-        endInput.addEventListener('input', update);
-        document.getElementById('swap-btn').onclick = function () {
-            const start = document.getElementById('route-start');
-            const end = document.getElementById('route-end');
-            const tmp = start.value;
-            start.value = end.value;
+        const searchBtn = document.getElementById('route-search-btn');
+        const loadingBar = document.getElementById('route-loading');
+
+        function showLoading() {
+            if (loadingBar) loadingBar.style.display = '';
+        }
+
+        function hideLoading() {
+            if (loadingBar) loadingBar.style.display = 'none';
+        }
+
+        function triggerSearch() {
+            showLoading();
+            update().finally(hideLoading);
+        }
+
+        searchBtn?.addEventListener('click', triggerSearch);
+        [startInput, endInput].forEach(inp =>
+            inp.addEventListener('keydown', e => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    triggerSearch();
+                }
+            })
+        );
+
+       document.getElementById('swap-btn').onclick = function () {
+           const start = document.getElementById('route-start');
+           const end = document.getElementById('route-end');
+           const tmp = start.value;
+           start.value = end.value;
             end.value = tmp;
-            update(); // Directly update results, do not trigger input events
+            triggerSearch(); // Update results after swap
         };
     });
 
@@ -643,7 +667,6 @@
                     input.value = st;
                     suggestionsDiv.innerHTML = '';
                     suggestionsDiv.classList.remove('active');
-                    input.dispatchEvent(new Event('input'));
                     isClickingOnSuggestion = false;
                     input.focus(); // Keep focus on input
                 };


### PR DESCRIPTION
## Summary
- show a new "Pretraži" button for route search
- display a loading progress bar while computing routes
- change path-search to trigger search on button click or Enter key
- tidy autocomplete to not auto-search on click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868850e651c8328a9b0bb9cb371d789