### PR TITLE
Fix duplicate transfer stations

### DIFF
--- a/js/path-search.js
+++ b/js/path-search.js
@@ -410,8 +410,15 @@
                     const stopNames0 = sch0.stops.map(s => s.name);
 
                     // Sort transfer options chronologically by their arrival time on the first line
-                    group.transferOptions.sort((a, b) => {
-                        return parseTime(a.transferArr) - parseTime(b.transferArr);
+                    group.transferOptions.sort((a, b) => parseTime(a.transferArr) - parseTime(b.transferArr));
+
+                    // Remove duplicate transfer options that have the same line and times
+                    const seenTransfers = new Set();
+                    group.transferOptions = group.transferOptions.filter(opt => {
+                        const key = `${opt.line}|${opt.dep}|${opt.arr}`;
+                        if (seenTransfers.has(key)) return false;
+                        seenTransfers.add(key);
+                        return true;
                     });
 
                     // Find the first transfer point that is a short walk from the destination


### PR DESCRIPTION
## Summary
- prevent repeated transfer options when multiple lines share the same times

## Testing
- `node script2.js | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6868c920329883289ed2c1cb4981d529