### PR TITLE
Refactor component loading and time helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
   <link rel="stylesheet" href="css/utils.css" />
   <link rel="stylesheet" href="css/page.css" />
   <link rel="stylesheet" href="css/route-map.css" />
+  <script src="js/modules/componentLoader.js"></script>
   <script src="js/components.js"></script>
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
@@ -942,6 +943,7 @@
   <script src="../js/index.js"></script>
 
   <script src="js/search-lines.js"></script>
+  <script src="js/utils/time.js"></script>
   <script src="js/path-search.js"></script>
 
 

--- a/js/components.js
+++ b/js/components.js
@@ -1,22 +1,5 @@
-document.addEventListener('DOMContentLoaded', function () {
-    // Load all components with data-component attribute
-    const components = document.querySelectorAll('[data-component]');
-
-    components.forEach(element => {
-        const componentName = element.getAttribute('data-component');
-
-        fetch(`/components/${componentName}.html`)
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`Failed to load component: ${componentName}`);
-                }
-                return response.text();
-            })
-            .then(html => {
-                element.innerHTML = html;
-            })
-            .catch(error => {
-                console.error(error);
-            });
-    });
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-component]').forEach(el => {
+    window.ComponentLoader && window.ComponentLoader.load(el);
+  });
 });

--- a/js/main.js
+++ b/js/main.js
@@ -1,21 +1,6 @@
-document.addEventListener('DOMContentLoaded', function () {
-    const elements = document.querySelectorAll('[data-component]');
-    elements.forEach(async (element) => {
-        const componentName = element.dataset.component;
-        // Use a prefix from the body tag to build the correct path
-        const basePath = document.body.dataset.pathPrefix || '';
-        const componentPath = `${basePath}components/${componentName}.html`;
-
-        try {
-            const response = await fetch(componentPath);
-            if (!response.ok) {
-                throw new Error(`Could not load component: ${response.statusText}`);
-            }
-            const text = await response.text();
-            element.innerHTML = text;
-        } catch (error) {
-            console.error(`Failed to load component ${componentName}:`, error);
-            element.innerHTML = `<p style="color:red; text-align:center;">Error: Component '${componentName}' could not be loaded.</p>`;
-        }
-    });
+document.addEventListener('DOMContentLoaded', () => {
+  const basePath = document.body.dataset.pathPrefix || '';
+  document.querySelectorAll('[data-component]').forEach(el => {
+    window.ComponentLoader && window.ComponentLoader.load(el, basePath);
+  });
 });

--- a/js/modules/componentLoader.js
+++ b/js/modules/componentLoader.js
@@ -1,0 +1,15 @@
+(function(global) {
+  async function load(element, basePath = '') {
+    const name = element.dataset.component;
+    if (!name) return;
+    const path = `${basePath}components/${name}.html`;
+    try {
+      const resp = await fetch(path);
+      if (!resp.ok) throw new Error(`Failed to load component: ${name}`);
+      element.innerHTML = await resp.text();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  global.ComponentLoader = { load };
+})(window);

--- a/js/path-search.js
+++ b/js/path-search.js
@@ -13,6 +13,7 @@
     // Precomputed indices
     const stationIndices = new Map();
     const stationToLines = new Map();
+    const { parseTime, formatTime } = window.TimeUtils;
 
     // Fetch schedule JSON for a given line code (e.g., "line_1A")
     async function fetchSchedule(lineCode) {
@@ -35,18 +36,6 @@
         }
     }
 
-    // Parse time "HH:MM" into minutes since midnight
-    function parseTime(t) {
-        const [h, m] = t.split(':').map(Number);
-        return h * 60 + m;
-    }
-
-    // Format minutes since midnight back to "HH:MM"
-    function formatTime(mins) {
-        const h = String(Math.floor(mins / 60)).padStart(2, '0');
-        const m = String(mins % 60).padStart(2, '0');
-        return `${h}:${m}`;
-    }
 
     // Load all schedules referenced on the page
     async function loadAllSchedules() {
@@ -118,38 +107,6 @@
         }
     }
 
-    // Load all schedules referenced on the page
-    async function loadAllSchedules() {
-        if (schedulesLoaded) return;
-
-
-
-        try {
-            // Get list of all line files (you'll need to maintain this list)
-            const lineFiles = ["line_1A.json", "line_1B.json", "line_2A.json", "line_2B.json", "line_3A.json", "line_3B.json", "line_4A.json", "line_4B.json", "line_5A.json", "line_5B.json", "line_6A.json", "line_6B.json", "line_7A.json", "line_7B.json", "line_8A.json", "line_8B.json", "line_9A.json", "line_9B.json", "line_10A.json", "line_10B.json", "line_11A.json", "line_11B.json", "line_12A.json", "line_12B.json", "line_13A.json", "line_13B.json", "line_14A.json", "line_14B.json", "line_15A.json", "line_15B.json", "line_16A.json", "line_16B.json", "line_17A.json", "line_17B.json", "line_18A.json", "line_18B.json", "line_20A.json", "line_20B.json", "line_22A.json", "line_22B.json", "line_23A.json", "line_23B.json", "line_24A.json", "line_24B.json", "line_25A.json", "line_25B.json", "line_26A.json", "line_26B.json", "line_28A.json", "line_28B.json", "line_29A.json", "line_29B.json", "line_30A.json", "line_30B.json", "line_31A.json", "line_31B.json", "line_32A.json", "line_32B.json", "line_33A.json", "line_33B.json", "line_34A.json", "line_34B.json", "line_35A.json", "line_35B.json"
-            ];
-
-            const promises = lineFiles.map(async (filename) => {
-                try {
-                    const response = await fetch(`assets/schedules/${filename}`);
-                    if (response.ok) {
-                        const schedule = await response.json();
-                        const lineId = filename.replace('.json', '');
-                        scheduleCache[lineId] = schedule;
-                    }
-                } catch (error) {
-                    console.warn(`Failed to load ${filename}:`, error);
-                }
-            });
-
-            await Promise.all(promises);
-            schedulesLoaded = true;
-
-
-        } catch (error) {
-            console.error('Error loading schedules:', error);
-        }
-    }
 
     // Patch loadAllSchedules to precompute indices after loading
     const origLoadAllSchedules = loadAllSchedules;

--- a/js/utils/time.js
+++ b/js/utils/time.js
@@ -1,0 +1,12 @@
+(function(global) {
+  function parseTime(t) {
+    const [h, m] = t.split(':').map(Number);
+    return h * 60 + m;
+  }
+  function formatTime(mins) {
+    const h = String(Math.floor(mins / 60)).padStart(2, '0');
+    const m = String(mins % 60).padStart(2, '0');
+    return `${h}:${m}`;
+  }
+  global.TimeUtils = { parseTime, formatTime };
+})(window);

--- a/linije/line_10A.html
+++ b/linije/line_10A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_10B.html
+++ b/linije/line_10B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_11A.html
+++ b/linije/line_11A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_11B.html
+++ b/linije/line_11B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_12A.html
+++ b/linije/line_12A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_12B.html
+++ b/linije/line_12B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_13A.html
+++ b/linije/line_13A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_13B.html
+++ b/linije/line_13B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_14A.html
+++ b/linije/line_14A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_14B.html
+++ b/linije/line_14B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_15a.html
+++ b/linije/line_15a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_15b.html
+++ b/linije/line_15b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_16a.html
+++ b/linije/line_16a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_16b.html
+++ b/linije/line_16b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_17a.html
+++ b/linije/line_17a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_17b.html
+++ b/linije/line_17b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_18a.html
+++ b/linije/line_18a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_18b.html
+++ b/linije/line_18b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_1A.html
+++ b/linije/line_1A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_1B.html
+++ b/linije/line_1B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_20a.html
+++ b/linije/line_20a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_20b.html
+++ b/linije/line_20b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_22a.html
+++ b/linije/line_22a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_22b.html
+++ b/linije/line_22b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_23a.html
+++ b/linije/line_23a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_23b.html
+++ b/linije/line_23b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_24a.html
+++ b/linije/line_24a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_24b.html
+++ b/linije/line_24b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_25a.html
+++ b/linije/line_25a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_25b.html
+++ b/linije/line_25b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_26a.html
+++ b/linije/line_26a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_26b.html
+++ b/linije/line_26b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_28a.html
+++ b/linije/line_28a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_28b.html
+++ b/linije/line_28b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_29a.html
+++ b/linije/line_29a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_29b.html
+++ b/linije/line_29b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_2A.html
+++ b/linije/line_2A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_2B.html
+++ b/linije/line_2B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_30a.html
+++ b/linije/line_30a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_30b.html
+++ b/linije/line_30b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_31a.html
+++ b/linije/line_31a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_31b.html
+++ b/linije/line_31b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_32a.html
+++ b/linije/line_32a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_32b.html
+++ b/linije/line_32b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_33a.html
+++ b/linije/line_33a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_33b.html
+++ b/linije/line_33b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_34a.html
+++ b/linije/line_34a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_34b.html
+++ b/linije/line_34b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_35a.html
+++ b/linije/line_35a.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_35b.html
+++ b/linije/line_35b.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_3A.html
+++ b/linije/line_3A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_3B.html
+++ b/linije/line_3B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_4A.html
+++ b/linije/line_4A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_4B.html
+++ b/linije/line_4B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_5A.html
+++ b/linije/line_5A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_5B.html
+++ b/linije/line_5B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_6A.html
+++ b/linije/line_6A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_6B.html
+++ b/linije/line_6B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_7A.html
+++ b/linije/line_7A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_7B.html
+++ b/linije/line_7B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_8A.html
+++ b/linije/line_8A.html
@@ -138,6 +138,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
   <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
   <script src="../js/main.js"></script>
 
   <!-- Page logic -->

--- a/linije/line_8B.html
+++ b/linije/line_8B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_9A.html
+++ b/linije/line_9A.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/linije/line_9B.html
+++ b/linije/line_9B.html
@@ -138,6 +138,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
     <!-- Component Loader -->
+    <script src="../js/modules/componentLoader.js"></script>
     <script src="../js/main.js"></script>
 
     <!-- Page logic -->

--- a/stations.html
+++ b/stations.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="css/page.css" />
     <link rel="stylesheet" href="css/route-map.css" />
     <link rel="stylesheet" href="css/stations.css" />
+    <script src="js/modules/componentLoader.js"></script>
     <script src="js/components.js"></script>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
@@ -122,6 +123,7 @@
     <script src="js/index.js"></script>
 
     <script src="js/search-lines.js"></script>
+    <script src="js/utils/time.js"></script>
     <script src="js/path-search.js"></script>
     <script src="js/stations.js"></script>
 


### PR DESCRIPTION
## Summary
- introduce `ComponentLoader` utility and refactor `components.js` and `main.js`
- add reusable time helpers and remove duplicate functions from `path-search.js`
- ensure pages load new helpers
- inject loader on all schedule pages

## Testing
- `node --check js/path-search.js`
- `node --check js/components.js`
- `node --check js/main.js`
- `node --check js/modules/componentLoader.js`
- `node --check js/utils/time.js`


------
https://chatgpt.com/codex/tasks/task_e_68889fc9fcbc8328b8ac9a7d4fc4f13e